### PR TITLE
feat(earnings model): include earning id in the earning model

### DIFF
--- a/__tests__/api-tests/earnings-api.spec.js
+++ b/__tests__/api-tests/earnings-api.spec.js
@@ -438,6 +438,7 @@ describe('Earnings API tests.', () => {
           let earnings_updated = false;
           for (const earning of res.body.earnings) {
             expect(earning).to.have.keys([
+              'id',
               'grower',
               'funder',
               'worker_id',

--- a/server/models/Earnings.js
+++ b/server/models/Earnings.js
@@ -4,6 +4,7 @@ const axios = require('axios').default;
 const stakeholderUrl = `${process.env.TREETRACKER_ENTITIES_URL}/stakeholder`;
 
 const Earning = async ({
+  id,
   worker_id,
   funder_id,
   amount,
@@ -30,6 +31,7 @@ const Earning = async ({
   );
 
   return Object.freeze({
+    id,
     worker_id,
     grower: growerResponse.data.stakeholders[0]?.name,
     funder_id,


### PR DESCRIPTION
JSON response returned by earnings API did not include `id` field. enhancement has been made in earnings model to include the `id` field